### PR TITLE
fixed a bug where gnomes still have food in their inventory when sparetime ends

### DIFF
--- a/Data/Scripts/classes/zwerg/change_z_spare_procs.tcl
+++ b/Data/Scripts/classes/zwerg/change_z_spare_procs.tcl
@@ -1,0 +1,18 @@
+$start
+$replace
+proc sparetime_eat_end {} {
+	global sparetime_disappointment sparetime_eat_item
+	set sparetime_eat_item 0
+	sparetime_check_in 0
+	set sparetime_disappointment 0.0
+$with
+proc sparetime_eat_end {} {
+	global sparetime_disappointment sparetime_eat_item
+	if {[lsearch [inv_list this] $sparetime_eat_item]!=-1} {
+		log "mealtime ends, so I will drop my leftovers ([get_objname $sparetime_eat_item])"
+		beamto_world $sparetime_eat_item
+	}
+	set sparetime_eat_item 0
+	sparetime_check_in 0
+	set sparetime_disappointment 0.0
+$end


### PR DESCRIPTION
The bug occurs when their spare time ends while they are on their way to pick up a food item. With this fix they will simply drop the item after picking it up. This may sound weird, but it is the easiest fix.

fixes #18 