### PR TITLE
bugfix: reduced mood loss due to bad sleep quality by 50%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - bugfix: when the floor is already cluttered with stuff, gnomes might fail to lay down an item they just produced
 - bugfix: hospital might get stuck when a patient dies during treatment
 - bugfix: fixed the goal for mood during sparetime acivities
+- bugfix: removed duplicate code section, thus reducing mood loss due to bad sleep quality by 50%
 
 ## [v1.5] - 2024-08-25
 ### Added

--- a/Data/Scripts/classes/zwerg/change_z_spare_main.tcl
+++ b/Data/Scripts/classes/zwerg/change_z_spare_main.tcl
@@ -62,3 +62,19 @@ $with
 						}
 						if {[lindex $sparetime_goal 1]>[get_attrib this atr_Mood]+0.01} {
 $end
+
+$start
+$replace
+		if {$civ_state>$funloss_slpquality} {
+			set moodloss [expr {$civ_state-$funloss_slpquality}]
+			sparetime_talkissue_entry "slp" $moodloss 0
+			set moodloss [expr {$moodfactor*$moodloss}]
+			fincr tll_fl_slpquality $moodloss
+			fincr sumloss $moodloss
+		}
+		set funstations 0
+		for {set i 1} {$i<17} {set i [expr {$i<<1}]} {
+$with
+		set funstations 0
+		for {set i 1} {$i<17} {set i [expr {$i<<1}]} {
+$end


### PR DESCRIPTION
The previous code looks wrong, the portion calculating mood loss appears twice (two identical copies). This change removes one of the copies, thus reducing the mood loss by 50%. (Only applies to "sleep quality", i.e. the level of bedrooms.)

This fix deliberately removes the second of two identical code sections. Removing the first one instead would cause a conflict with the RevisedPlanner mod, which slightly changes the first section.